### PR TITLE
Update Kubernetes Admission Control tutorial

### DIFF
--- a/docs/book/tutorials/kubernetes-admission-control-validation/admission-controller.yaml
+++ b/docs/book/tutorials/kubernetes-admission-control-validation/admission-controller.yaml
@@ -1,0 +1,78 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: opa
+spec:
+  selector:
+    app: opa
+  ports:
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: 443
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: opa
+  name: opa
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: opa
+      name: opa
+    spec:
+      containers:
+        - name: opa
+          image: openpolicyagent/opa:0.6.0
+          args:
+            - "run"
+            - "--server"
+            - "--tls-cert-file=/certs/tls.crt"
+            - "--tls-private-key-file=/certs/tls.key"
+            - "--addr=0.0.0.0:443"
+            - "--insecure-addr=127.0.0.1:8181"
+          volumeMounts:
+            - readOnly: true
+              mountPath: /certs
+              name: opa-server
+        - name: kube-mgmt
+          image: openpolicyagent/kube-mgmt:0.6
+          args:
+            - "--replicate-cluster=v1/namespaces"
+            - "--replicate=extensions/v1beta1/ingresses"
+      volumes:
+        - name: opa-server
+          secret:
+            secretName: opa-server
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: opa-default-system-main
+data:
+  main: |
+    package system
+
+    import data.kubernetes.admission
+
+    main = {
+      "apiVersion": "admission.k8s.io/v1beta1",
+      "kind": "AdmissionReview",
+      "response": response,
+    }
+
+    default response = {"allowed": true}
+
+    response = {
+        "allowed": false,
+        "status": {
+            "reason": reason,
+        },
+    } {
+        reason = concat(", ", admission.deny)
+        reason != ""
+    }

--- a/docs/book/tutorials/kubernetes-admission-control-validation/ingress-conflicts.rego
+++ b/docs/book/tutorials/kubernetes-admission-control-validation/ingress-conflicts.rego
@@ -1,0 +1,13 @@
+package kubernetes.admission
+
+import data.kubernetes.ingresses
+
+deny[msg] {
+	input.request.kind.kind = "Ingress"
+    input.request.operation = "CREATE"
+	host = input.request.object.spec.rules[_].host
+    ingress = ingresses[other_ns][other_ingress]
+    other_ns != input.request.namespace
+    ingress.spec.rules[_].host = host
+    msg = sprintf("invalid ingress host %q (conflicts with %v/%v)", [host, other_ns, other_ingress])
+}

--- a/docs/book/tutorials/kubernetes-admission-control-validation/ingress-whitelist.rego
+++ b/docs/book/tutorials/kubernetes-admission-control-validation/ingress-whitelist.rego
@@ -1,0 +1,36 @@
+package kubernetes.admission
+
+import data.kubernetes.namespaces
+
+deny[msg] {
+    input.request.kind.kind = "Ingress"
+    input.request.operation = "CREATE"
+	host = input.request.object.spec.rules[_].host
+	not fqdn_matches_any(host, valid_ingress_hosts)
+	msg = sprintf("invalid ingress host %q", [host])
+}
+
+valid_ingress_hosts = {host |
+	whitelist = namespaces[input.request.namespace].metadata.annotations["ingress-whitelist"]
+	hosts = split(whitelist, ",")
+	host = hosts[_]
+}
+
+fqdn_matches_any(str, patterns) {
+	fqdn_matches(str, patterns[_])
+}
+
+fqdn_matches(str, pattern) {
+	pattern_parts = split(pattern, ".")
+	pattern_parts[0] = "*"
+	str_parts = split(str, ".")
+	n_pattern_parts = count(pattern_parts)
+	n_str_parts = count(str_parts)
+	suffix = trim(pattern, "*.")
+	endswith(str, suffix)
+}
+
+fqdn_matches(str, pattern) {
+	not contains(pattern, "*")
+	str = pattern
+}


### PR DESCRIPTION
The v1.9 webhook support contains a bug that causes CONNECT operations
to fail. We can add the privileged exec example back once that's fixed.

Fixes #567